### PR TITLE
Disimport unicode_literals from setup script

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,4 @@
 #!/usr/bin/env python
-from __future__ import absolute_import, division, print_function, unicode_literals
-
 from setuptools import setup
 
 setup(name='dirtbike',


### PR DESCRIPTION
These imports seem to (a) serve no function and (b) spuriously break `distutils`. For example:

```
      File "/usr/local/Cellar/python/2.7.10/Frameworks/Python.framework/Versions/2.7/lib/python2.7/distutils/command/build_py.py", line 335, in build_module
        package)
    TypeError: u'dirtbike' must be a string (dot-separated), list, or tuple
```

It is not a `str` because `u'dirtbike'` is `unicode`. Lame but avoidable.
