### PR TITLE
Add ability to wheel packages w/o .egg-info

### DIFF
--- a/dirtbike/__init__.py
+++ b/dirtbike/__init__.py
@@ -55,8 +55,8 @@ def make_wheel_file(distribution_name):
         'version': strategy.version,
         })
 
-    # The wheel generator will clean up this file when it exits, but let's
-    # just be sure that any failures don't leave this directory.
+    # The wheel generator will clean up this directory when it exits, but
+    # let's just be sure that any failures don't leave this directory.
     bdist_dir = tempfile.mkdtemp()
     atexit.register(shutil.rmtree, bdist_dir, ignore_errors=True)
 

--- a/dirtbike/__init__.py
+++ b/dirtbike/__init__.py
@@ -10,6 +10,8 @@ import shutil
 import subprocess
 import wheel.bdist_wheel
 
+from .strategy import DpkgEggStrategy, WheelStrategy
+
 
 def _mkdir_p(dirname):
     if not dirname:
@@ -27,77 +29,29 @@ def _copy_file_making_dirs_as_needed(src, dst):
     shutil.copy(src, dst)
 
 
-# NOTE: For now, this module has some Debian-specific hacks
-# (invocations to dpkg -L, etc.) to make it useful immediately.
-#
-# I consider that a bug, not a feature. I'd like to remove the
-# Debian-specific code so that this can rely entirely in the pip
-# pseudo-standard of "installed-files.txt" etc. However, the
-# python-requests package in Debian testing (at the time of writing)
-# does not distribute an installed-files.txt, so probably it is useful
-# to have the Debian-specific code in this version.
-#
-# To be semver-esque, a version with the Debian-specific code
-# removed would presumably have a bumped "major" version number.
-def _get_files_list_via_debian(distribution_obj):
-    # Find the .egg-info directory, and then search the dpkg database
-    # for which package provides it.
-    path_to_egg_info = distribution_obj._provider.egg_info
-    as_bytes = subprocess.check_output([
-        '/usr/bin/dpkg', '-S', path_to_egg_info])
-    as_text = as_bytes.decode('utf-8')
-    pkg_name = as_text.split(':')[0]
-    files_list_as_bytes = subprocess.check_output([
-        '/usr/bin/dpkg', '-L', pkg_name])
-    files_list_as_text = files_list_as_bytes.decode('utf-8')
-    # Now we have all the files from the Debian package. However,
-    # RECORD-style files lists are all relative to the site-packages
-    # directory in which the package was installed.
-    ret = []
-    base_location = distribution_obj.location
-    for filename in files_list_as_text.split('\n'):
-        if filename.startswith(distribution_obj.location):
-            shortened_filename = filename[len(base_location):]
-            if shortened_filename.startswith('/'):
-                shortened_filename = shortened_filename[1:]
-            ret.append(shortened_filename)
-    return ret
-
-
-def _get_files_list_via_wheel_metadata(distribution_obj):
-    '''Return either the bytes of the RECORD file, or something
-    equivalent.  I hear installed-files.txt is a thing, but I haven't
-    found evidence for that yet.'''
-    try:
-        # If we're lucky, the information for what files are installed on the
-        # system are available in RECORD, aka wheel metadata.
-        return distribution_obj.get_metadata('RECORD').split('\n')
-    except IOError as e:
-        # Let's find the path to an egg-info file and ask dpkg for the
-        # file metadata.
-        if e.errno == 2:
-            return None
-        raise
-
-
 def make_wheel_file(distribution_name):
-    # Grab the metadata for the installed version of this
-    # distribution.
-    installed_package_metadata = pkg_resources.get_distribution(
-        distribution_name)
+    # Grab the metadata for the installed version of this distribution.
+    for strategy_class in (WheelStrategy, DpkgEggStrategy):
+        strategy = strategy_class(distribution_name)
+        if strategy.can_succeed:
+            break
+    else:
+        raise RuntimeError(
+            'No strategy for finding package contents: {}'.format(
+                distribution_name))
 
-    # Create Distribution object so that the wheel.bdist_wheel
-    # machinery can operate happily. We copy any metadata we need out
-    # of the installed package metadata into this thing.
+    # Create a Distribution object so that the wheel.bdist_wheel machinery can
+    # operate happily.  We copy any metadata we need out of the installed
+    # package metadata into this thing.
     dummy_dist_distribution_obj = distutils.dist.Distribution(attrs={
-        'name': installed_package_metadata.project_name,
-        'version': installed_package_metadata.version})
+        'name': strategy.name,
+        'version': strategy.version,
+        })
 
     wheel_generator = wheel.bdist_wheel.bdist_wheel(
         dummy_dist_distribution_obj)
 
-    # Copy files from the system into a place where wheel_generator
-    # will look.
+    # Copy files from the system into a place where wheel_generator will look.
     #
     # FIXME: Pull this out of wheel_generator.
     BUILD_PREFIX = 'build/bdist.linux-x86_64/wheel/'
@@ -106,39 +60,29 @@ def make_wheel_file(distribution_name):
         raise ValueError(
             "Yikes, I am afraid of inconsistent state and will bail out.")
 
-    files_list = _get_files_list_via_wheel_metadata(installed_package_metadata)
-    if not files_list:
-        # Let's try the Debian-specific hack, just in case.
-        files_list = _get_files_list_via_debian(installed_package_metadata)
-    if not files_list:
-        # Well, I don't know what to do.
-        raise RuntimeError("Cannot find files for this package. Bailing.")
+    if strategy.files is None:
+        raise RuntimeError('Strategy lied: {}'.format(strategy_class.__name__))
 
-    for line in files_list:
-        # NOTE: We currently ignore hashes and any other metadata.
-        filename = line.split(',')[0]
-
-        # The list of files sometimes contains the empty
-        # string. That's not much of a file, so we don't bother adding
-        # it to the archive.
-        if not filename:
+    for filename in strategy.files:
+        # The list of files sometimes contains the empty string. That's not
+        # much of a file, so we don't bother adding it to the archive.
+        if len(filename) == 0:
             continue
 
-        # NOTE: If a file is not in the "location" that the installed
-        # package supposedly lives in, we skip it. This means we are
-        # likely to skip console scripts.
+        # NOTE: If a file is not in the "location" that the installed package
+        # supposedly lives in, we skip it. This means we are likely to skip
+        # console scripts.
         if filename.startswith('/'):
             abspath = os.path.abspath(filename)
         else:
-            abspath = os.path.abspath(installed_package_metadata.location +
-                                      '/' + filename)
+            abspath = os.path.abspath(
+                os.path.join(strategy.location, filename))
 
         found = False
-        isfile = False
-        if (abspath.startswith(installed_package_metadata.location) and
-                os.path.exists(abspath)):
+        is_file = False
+        if abspath.startswith(strategy.location) and os.path.exists(abspath):
             found = True
-            isfile = os.path.isfile(abspath)
+            is_file = os.path.isfile(abspath)
 
         # Print a warning in the case that some file is missing, then skip it.
         if not found:
@@ -147,7 +91,7 @@ def make_wheel_file(distribution_name):
             continue
 
         # Skip directories.
-        if found and not isfile:
+        if found and not is_file:
             continue
 
         # Skip the dist-info directory, since bdist_wheel will
@@ -156,18 +100,17 @@ def make_wheel_file(distribution_name):
             continue
 
         # Skip any *.pyc files or files that are in a __pycache__ directory.
-        if (('__pycache__' in abspath) or
-                abspath.endswith('.pyc')):
+        if '__pycache__' in abspath or abspath.endswith('.pyc'):
             continue
 
-        # Since we actually do seem to want this file, let us copy it
-        # into the BUILD_PREFIX.
+        # Since we actually do seem to want this file, let us copy it into the
+        # BUILD_PREFIX.
         _copy_file_making_dirs_as_needed(
             abspath,
             os.path.abspath(BUILD_PREFIX + '/' + filename))
 
-    # Call finalize_options() to tell bdist_wheel we are done playing
-    # with metadata.
+    # Call finalize_options() to tell bdist_wheel we are done playing with
+    # metadata.
     wheel_generator.finalize_options()
 
     wheel_generator.run()  # OMG Rofl?

--- a/dirtbike/__main__.py
+++ b/dirtbike/__main__.py
@@ -1,0 +1,9 @@
+import sys
+from . import make_wheel_file
+
+def main():
+    make_wheel_file(sys.argv[1])
+
+
+if __name__ == '__main__':
+    main()

--- a/dirtbike/strategy.py
+++ b/dirtbike/strategy.py
@@ -1,0 +1,135 @@
+from __future__ import (
+    absolute_import, division, print_function, unicode_literals,
+    )
+
+
+import errno
+import subprocess
+import pkg_resources
+
+
+class Strategy(object):
+    """Encapsulation of a distribution's contents strategies."""
+
+    def __init__(self, name):
+        self._name = name
+
+    @property
+    def name(self):
+        """The project's name."""
+        return self._name
+
+    @property
+    def can_succeed(self):
+        """A boolean which describes whether this strategy can succeed."""
+        raise NotImplementedError
+
+    @property
+    def version(self):
+        """The version associated with the installed package."""
+
+    @property
+    def files(self):
+        """A list of files contained in the package or None.
+
+        If this strategy cannot find the named package's contents, this
+        attribute will be None.
+        """
+        raise NotImplementedError
+
+    @property
+    def location(self):
+        """The metadata location."""
+        raise NotImplementedError
+
+
+class WheelStrategy(Strategy):
+    """Use wheel metadata to find package contents."""
+
+    def __init__(self, name):
+        super(WheelStrategy, self).__init__(name)
+        self._metadata = pkg_resources.get_distribution(self._name)
+        self._files = None
+        try:
+            # If we're lucky, the information for what files are installed on
+            # the system are available in RECORD, aka wheel metadata.
+            self.files = self._metadata.get_metadata('RECORD').splitlines()
+        # Python 3 - use FileNotFoundError
+        except IOError as error:
+            # Let's find the path to an egg-info file and ask dpkg for the
+            # file metadata.
+            if error.errno != errno.ENOENT:
+                raise
+
+    @property
+    def can_succeed(self):
+        return self.files is not None
+
+    @property
+    def version(self):
+        return self._metadata.version
+
+    @property
+    def files(self):
+        return self._files
+
+    @property
+    def name(self):
+        return self._metadata.project_name
+
+
+class DpkgEggStrategy(Strategy):
+    """Use Debian-specific strategy for finding a package's contents."""
+
+    # It would be nice to be able to remove the Debian-specific code so that
+    # this can rely entirely in the pip pseudo-standard of
+    # "installed-files.txt" etc.  However, packages in Debian testing do not
+    # yet distribute an installed-files.txt, so probably it is useful to have
+    # the Debian-specific code in this version.
+    #
+    # To be semver-esque, a version with the Debian-specific code
+    # removed would presumably have a bumped "major" version number.
+    def __init__(self, name):
+        super(DpkgEggStrategy, self).__init__(name)
+        self._metadata = pkg_resources.get_distribution(name)
+        # Find the .egg-info directory, and then search the dpkg database for
+        # which package provides it.
+        path_to_egg_info = self._metadata._provider.egg_info
+        stdout = subprocess.check_output(
+            ['/usr/bin/dpkg', '-S', path_to_egg_info],
+            universal_newlines=True)
+        pkg_name, colon, path = stdout.partition(':')
+        stdout = subprocess.check_output(
+            ['/usr/bin/dpkg', '-L', pkg_name],
+            universal_newlines=True)
+        # Now we have all the files from the Debian package.  However,
+        # RECORD-style files lists are all relative to the site-packages
+        # directory in which the package was installed.
+        self._files = []
+        base_location = self._metadata.location
+        for filename in stdout.splitlines():
+            if filename.startswith(self._metadata.location):
+                shortened_filename = filename[len(base_location):]
+                if shortened_filename.startswith('/'):
+                    shortened_filename = shortened_filename[1:]
+                self._files.append(shortened_filename)
+
+    @property
+    def name(self):
+        return self._metadata.project_name
+
+    @property
+    def can_succeed(self):
+        return self._metadata is not None
+
+    @property
+    def version(self):
+        return self._metadata.version
+
+    @property
+    def files(self):
+        return self._files
+
+    @property
+    def location(self):
+        return self._metadata.location

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ setup(name='dirtbike',
       ],
       entry_points={
           'console_scripts': [
-              'dirtbike = dirtbike:main',
+              'dirtbike = dirtbike.__main__:main',
           ],
       },
 )


### PR DESCRIPTION
Several useful changes here.
- We can now wheel up packages that don't have an .egg-info directory.  An example of this is pkg_resources which is split from setuptools in Debian.
- Refactors the file discovery algorithms into separate "strategy" classes, and a separate submodule.
- Generate universal wheels, since that's all we care about in Debian (eventually, this will be a cli option).
- Use an actual temporary directory instead of hard coding the default.
- Little cleanups.
- Add support for `python -m dirtbike`
