### PR TITLE
Add real argument parsing

### DIFF
--- a/dirtbike/__main__.py
+++ b/dirtbike/__main__.py
@@ -1,8 +1,26 @@
-import sys
+import argparse
+
 from . import make_wheel_file
 
+
+def parseargs():
+    parser = argparse.ArgumentParser('Turn OS packages into wheels')
+    parser.add_argument('-d', '--directory',
+                        help="""Leave the new .whl file in the given directory.
+                        Otherwise the default is to use the current working
+                        directory.  If DIRECTORY doesn't exist, it will be
+                        created.""")
+    parser.add_argument('package', nargs=1,
+                        help="""The name of the package to rewheel, as seen by
+                        Python (not your OS!).""")
+    return parser.parse_args()
+
+
 def main():
-    make_wheel_file(sys.argv[1])
+    args = parseargs()
+    # For convenience and readability of make_wheel_file().
+    args.package = args.package[0]
+    make_wheel_file(args)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Also, add -d/--directory to indicate where the resulting .whl should
go.  The default is the pwd, which is a behavior change from dirtbike
0.1.

But at least we have real --help now!
