### PR TITLE
A strategy for cross-Python import

### DIFF
--- a/dirtbike/__init__.py
+++ b/dirtbike/__init__.py
@@ -12,14 +12,17 @@ import wheel.bdist_wheel
 
 from glob import glob
 from .strategy import (
-    DpkgEggStrategy, DpkgImpStrategy, DpkgImportlibStrategy, WheelStrategy)
+    DpkgEggStrategy, DpkgImpStrategy, DpkgImportCalloutStrategy,
+    DpkgImportlibStrategy, WheelStrategy)
 
 
 STRATEGIES = (
+    # The order is significant here, so DO NOT sort alphabetically.
     WheelStrategy,
     DpkgEggStrategy,
     DpkgImportlibStrategy,
     DpkgImpStrategy,
+    DpkgImportCalloutStrategy,
     )
 
 


### PR DESCRIPTION
This adds another strategy for rewheeling a package that is only importable by a different Python version.  For example, let's say you want to create a wheel of ipaddress.  In Debian, this package only exists as a Python 2 package, i.e. python-ipaddress.  This is because in Python 3, it's a stdlib package.  This new strategy allows you to run dirtbike as a Python 3 application, and it will shell out to Python 2 to get the import location of the .py file.  From there, the same dpkg calls will provide all the necessary information.

Landing this will allow #5 to be addressed, although I won't close that issue with this commit, since I'd like to Python 3-ify the code at that point.
