### PR TITLE
Update WheelStrategy to handle RECORD with commas

### DIFF
--- a/dirtbike/strategy.py
+++ b/dirtbike/strategy.py
@@ -101,7 +101,11 @@ class WheelStrategy(Strategy):
         try:
             # If we're lucky, the information for what files are installed on
             # the system are available in RECORD, aka wheel metadata.
-            files = self._metadata.get_metadata('RECORD').splitlines()
+            # RECORD may also have sha256sum and file size, we only want the
+            # name.
+            files = []
+            for line in self._metadata.get_metadata('RECORD').splitlines():
+                files.append(line.split(',')[0])
         # Python 3 - use FileNotFoundError
         except IOError as error:
             self._files = None


### PR DESCRIPTION
Packages produced by tools like flit and pip have more than just the filename in RECORD.  They have:
filename,sha256sum,filesize
For dirtbike's purposes we just need to split on commas and take the first part.  For older style RECORD files with just filename, this still works.